### PR TITLE
fix(deps): remove optional 'toml' extra from coverage to fix install error

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -84,7 +84,7 @@ contourpy==1.3.2
     # via
     #   -r /workspaces/greenova/requirements/requirements.in
     #   matplotlib
-coverage[toml]==7.8.0
+coverage==7.8.0
     # via
     #   -r /workspaces/greenova/requirements/requirements.in
     #   pytest-cov


### PR DESCRIPTION
This PR updates the `coverage` dependency by removing the optional `[toml]` extra.  
The previous declaration `coverage[toml]==7.8.0` caused installation errors.  
Changing it to `coverage==7.8.0` resolves the issue and keeps the version consistent.