### PR TITLE
Fix breadcrumbs navigation to use BreadcrumbMixin context (closes #106)

### DIFF
--- a/greenova/templates/layouts/_breadcrumbs.html
+++ b/greenova/templates/layouts/_breadcrumbs.html
@@ -1,11 +1,22 @@
+{% load core_tags %}
 <nav aria-label="Breadcrumb navigation"
      role="navigation"
      class="breadcrumbs">
   <ul class="breadcrumbs-list">
-    <li>
-      <a href="{% url 'dashboard:home' %}" role="menuitem" aria-current="page">Dashboard</a>
-    </li>
-    {% block breadcrumbs %}
-    {% endblock breadcrumbs %}
+    {% if breadcrumbs %}
+      {% for label, url in breadcrumbs %}
+        <li>
+          {% if url %}
+            <a href="{% if url == 'home' %}{% url 'dashboard:home' %}{% else %}{{ url }}{% endif %}" role="menuitem">{{ label }}</a>
+          {% else %}
+            <span aria-current="page">{{ label }}</span>
+          {% endif %}
+        </li>
+      {% endfor %}
+    {% else %}
+      <li>
+        <a href="{% url 'dashboard:home' %}" role="menuitem" aria-current="page">Dashboard</a>
+      </li>
+    {% endif %}
   </ul>
 </nav>


### PR DESCRIPTION
## Bug Fix

The breadcrumbs navigation was not functional because  hardcoded a Dashboard link and ignored the  context provided by .

## Fix

-  now checks for  in template context
- If present, renders each breadcrumb with label and URL
- Falls back to Dashboard link when no breadcrumbs in context
- Uses Django  for home route resolution

## Testing

- Verified template syntax is valid
- Backward compatible: pages without BreadcrumbMixin still show Dashboard
